### PR TITLE
Fix route filter in prediction dashboard

### DIFF
--- a/dashboard_predictions.py
+++ b/dashboard_predictions.py
@@ -127,7 +127,8 @@ def update_dashboard(route, modell):
     if route == 'ALL':
         y_true_2024 = y_true_2024.groupby('DATE')['PASSENGERS'].sum()
     else:
-        y_true_2024 = y_true_2024[(df['ORIGIN'] == origin) & (df['DEST'] == dest)].set_index('DATE')['PASSENGERS']
+        # Filter innerhalb des bereits eingegrenzten 2024-Datensatzes vornehmen
+        y_true_2024 = y_true_2024[(y_true_2024['ORIGIN'] == origin) & (y_true_2024['DEST'] == dest)].set_index('DATE')['PASSENGERS']
 
     forecast = []
     y_pred = []


### PR DESCRIPTION
## Summary
- correct filtering of 2024 actual data for chosen route in `dashboard_predictions.py`

## Testing
- `python -m py_compile dashboard_predictions.py`

------
https://chatgpt.com/codex/tasks/task_e_68492b8c7ec4832c9e8c90560c780a4c