### PR TITLE
Add ARIMA cross validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,4 @@ aggregierte_verbindungen.csv Eigentlich der Datensatz, den wir brauchen (Eine Ze
 Update: verbindungen_mit_kennzahlen.csv ist ergänzter Datensatz mit Passergers pro Flug und Auslastung
 
 Dashboard: dashboard.py aktuell mit Vorhersage für 2024 durch lineare Regression
+arima_cv.py Cross-Validation von ARIMA-Modellen ueber alle Verbindungen; schreibt Ergebnisse in arima_cv_results.csv

--- a/arima_cv.py
+++ b/arima_cv.py
@@ -1,0 +1,88 @@
+import pandas as pd
+import numpy as np
+from statsmodels.tsa.arima.model import ARIMA
+from sklearn.metrics import mean_absolute_error, mean_squared_error, r2_score
+from itertools import product
+
+# Load list of connections to evaluate
+connections = pd.read_csv("passed_connections.csv", dtype={"UNIQUE_CARRIER_ENTITY": str})
+
+# Load main dataset
+data = pd.read_csv("verbindungen_mit_kennzahlen.csv", dtype={"UNIQUE_CARRIER_ENTITY": str})
+
+# Prepare date column and sorting
+data['DATE'] = pd.to_datetime(data[['YEAR', 'MONTH']].assign(DAY=1))
+data.sort_values('DATE', inplace=True)
+
+# Parameter grid for ARIMA(p,d,q)
+p_values = [0, 1, 2]
+d_values = [0, 1]
+q_values = [0, 1, 2]
+params_grid = list(product(p_values, d_values, q_values))
+
+
+def evaluate_split(train, test, order):
+    """Fit ARIMA on train and forecast the length of test."""
+    try:
+        model = ARIMA(train, order=order).fit()
+        forecast = model.forecast(len(test))
+    except Exception:
+        return None
+    mae = mean_absolute_error(test, forecast)
+    rmse = np.sqrt(mean_squared_error(test, forecast))
+    r2 = r2_score(test, forecast)
+    return mae, rmse, r2
+
+
+def connection_splits(df_conn):
+    """Create two train/test splits if enough data is available."""
+    df_conn = df_conn.set_index("DATE").sort_index()
+    train1 = df_conn[df_conn.index.year == 2022]["PASSENGERS"]
+    test1 = df_conn[df_conn.index.year == 2023]["PASSENGERS"]
+    train2 = df_conn[df_conn.index.year <= 2023]["PASSENGERS"]
+    test2 = df_conn[df_conn.index.year == 2024]["PASSENGERS"]
+    if len(train1) >= 12 and len(test1) >= 12 and len(train2) >= 24 and len(test2) >= 12:
+        return [(train1, test1), (train2, test2)]
+    return []
+
+
+results = []
+
+for order in params_grid:
+    fold_metrics = []
+    for _, conn in connections.iterrows():
+        mask = (
+            (data["AIRLINE_ID"] == conn["AIRLINE_ID"]) &
+            (data["UNIQUE_CARRIER_ENTITY"] == conn["UNIQUE_CARRIER_ENTITY"]) &
+            (data["ORIGIN"] == conn["ORIGIN"]) &
+            (data["DEST"] == conn["DEST"]) &
+            (data["AIRCRAFT_TYPE"] == conn["AIRCRAFT_TYPE"])
+        )
+        df_conn = data[mask]
+        splits = connection_splits(df_conn)
+        for train, test in splits:
+            metrics = evaluate_split(train, test, order)
+            if metrics:
+                fold_metrics.append(metrics)
+    if fold_metrics:
+        arr = np.array(fold_metrics)
+        results.append({
+            "p": order[0],
+            "d": order[1],
+            "q": order[2],
+            "MAE": arr[:, 0].mean(),
+            "RMSE": arr[:, 1].mean(),
+            "R2": arr[:, 2].mean(),
+        })
+
+results_df = pd.DataFrame(results)
+results_df = results_df.sort_values(by=["RMSE"]).reset_index(drop=True)
+
+print("Mean metrics over all connections per parameter combination:")
+print(results_df)
+
+best = results_df.iloc[0]
+print("\nBest parameter set:")
+print(best)
+
+results_df.to_csv("arima_cv_results.csv", index=False)


### PR DESCRIPTION
## Summary
- add `arima_cv.py` for evaluating ARIMA(p,d,q) models over all connections
- document ARIMA CV script in `README.md`

## Testing
- `python arima_cv.py` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6849333a9870832c9b0089dbb05bed85