### PR TITLE
Add 2025 forecasts to dashboards

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,5 +9,5 @@ aggregierte_verbindungen.csv Eigentlich der Datensatz, den wir brauchen (Eine Ze
 
 Update: verbindungen_mit_kennzahlen.csv ist ergänzter Datensatz mit Passergers pro Flug und Auslastung
 
-Dashboard: dashboard.py aktuell mit Vorhersage für 2024 durch lineare Regression
+Dashboard: dashboard.py erstellt nun Vorhersagen für 2024 und 2025 mittels linearer Regression
 arima_cv.py Cross-Validation von ARIMA-Modellen ueber alle Verbindungen; schreibt Ergebnisse in arima_cv_results.csv

--- a/dashboard.py
+++ b/dashboard.py
@@ -105,12 +105,18 @@ def update_dashboard(route):
     model = LinearRegression()
     model.fit(X, y)
 
-    # Prognose für 2024
-    future_dates = pd.date_range(start='2024-01-01', end='2024-12-01', freq='MS')
+    # Prognose für 2024 und 2025
+    future_dates = pd.date_range(start='2024-01-01', end='2025-12-01', freq='MS')
     future_timestamps = (future_dates - dff['DATE'].min()).days.values.reshape(-1, 1)
     future_preds = model.predict(future_timestamps)
 
-    fig.add_scatter(x=future_dates, y=future_preds, name='Prognose 2024', mode='lines', line=dict(dash='dash'))
+    fig.add_scatter(
+        x=future_dates,
+        y=future_preds,
+        name='Prognose 2024-2025',
+        mode='lines',
+        line=dict(dash='dash')
+    )
 
     # Metriken
     y_pred = model.predict(X)

--- a/dashboard_predictions.py
+++ b/dashboard_predictions.py
@@ -122,7 +122,7 @@ def update_dashboard(route, modell):
         html.Tr([html.Td("Standardabweichung"), html.Td(f"{dff['PASSENGERS'].std():,.0f}")]),
     ])
 
-    future_dates = pd.date_range(start='2024-01-01', end='2024-12-01', freq='MS')
+    future_dates = pd.date_range(start='2024-01-01', end='2025-12-01', freq='MS')
     y_true_2024 = df[df['DATE'].between('2024-01-01', '2024-12-31')]
     if route == 'ALL':
         y_true_2024 = y_true_2024.groupby('DATE')['PASSENGERS'].sum()
@@ -155,20 +155,20 @@ def update_dashboard(route, modell):
             )
             model_fit = model.fit(optimized=True)
             y_pred = model_fit.fittedvalues
-            forecast = model_fit.forecast(12)
+            forecast = model_fit.forecast(24)
 
         elif modell == 'ARIMA':
             # Best parameters from cross validation
             model = ARIMA(dff['PASSENGERS'], order=(1, 0, 1))
             model_fit = model.fit()
             y_pred = model_fit.predict(start=1, end=len(dff)-1, typ="levels")
-            forecast = model_fit.forecast(12)
+            forecast = model_fit.forecast(24)
 
         elif modell == 'SARIMA':
             model = SARIMAX(dff['PASSENGERS'], order=(0,0,0), seasonal_order=(1,1,0,12))
             model_fit = model.fit(disp=False)
             y_pred = model_fit.fittedvalues
-            forecast = model_fit.forecast(12)
+            forecast = model_fit.forecast(24)
 
         elif modell == 'PROPHET':
             prophet_df = dff[['DATE', 'PASSENGERS']].rename(columns={'DATE': 'ds', 'PASSENGERS': 'y'})
@@ -189,12 +189,19 @@ def update_dashboard(route, modell):
             mode='lines+markers',
             line=dict(color='green', width=2, dash='dot')
             )
-        fig.add_scatter(x=future_dates, y=forecast, name='Prognose 2024', mode='lines', line=dict(dash='dash'))
+        fig.add_scatter(
+            x=future_dates,
+            y=forecast,
+            name='Prognose 2024-2025',
+            mode='lines',
+            line=dict(dash='dash')
+        )
 
         # Metriken berechnen
-        mae = mean_absolute_error(y_true_2024, forecast)
-        rmse = np.sqrt(mean_squared_error(y_true_2024, forecast))
-        r2 = r2_score(y_true_2024, forecast)
+        forecast_2024 = forecast[:len(y_true_2024)]
+        mae = mean_absolute_error(y_true_2024, forecast_2024)
+        rmse = np.sqrt(mean_squared_error(y_true_2024, forecast_2024))
+        r2 = r2_score(y_true_2024, forecast_2024)
 
     except Exception as e:
         print("Fehler bei Prognose:", e)


### PR DESCRIPTION
## Summary
- extend future prediction window in `dashboard.py`
- extend forecasting horizon to 2025 in `dashboard_predictions.py`
- adjust metric calculation to use only the 2024 portion
- update README about dashboard forecasts

## Testing
- `python -m py_compile dashboard.py dashboard_predictions.py`

------
https://chatgpt.com/codex/tasks/task_e_685a4e3d1e64832c949d27d483e34f19