### PR TITLE
Suppress statsmodels convergence warnings in dashboard predictions

### DIFF
--- a/dashboard_predictions.py
+++ b/dashboard_predictions.py
@@ -10,6 +10,10 @@ from statsmodels.tsa.holtwinters import ExponentialSmoothing
 from statsmodels.tsa.arima.model import ARIMA
 from statsmodels.tsa.statespace.sarimax import SARIMAX
 from prophet import Prophet
+import warnings
+from statsmodels.tools.sm_exceptions import ConvergenceWarning
+
+warnings.filterwarnings("ignore", category=ConvergenceWarning)
 
 # Daten laden
 df = pd.read_csv(


### PR DESCRIPTION
## Summary
- avoid noisy output from Holt-Winters by ignoring `ConvergenceWarning` in `dashboard_predictions.py`

## Testing
- `python -m py_compile dashboard_predictions.py`


------
https://chatgpt.com/codex/tasks/task_e_686b70187a78832c86a02f11ff06ba9a